### PR TITLE
スタートページを実装

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -110,7 +110,7 @@ SPEC CHECKSUMS:
   FirebaseAuth: 21d5e902fcea44d0d961540fc4742966ae6118cc
   FirebaseCore: b68d3616526ec02e4d155166bbafb8eca64af557
   FirebaseCoreInternal: d2b4acb827908e72eca47a9fd896767c3053921e
-  FirebaseFirestore: bfafc0d3ecf3e9f1a706c4a3fa1567c09d9f83fd
+  FirebaseFirestore: 8418f3a8d5892bf386b05d5f988b6e7e253a2ea6
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
   GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,13 +2,18 @@
 import 'package:flutter/material.dart';
 import 'package:spicy_ranking/view/input_page.dart';
 import 'package:spicy_ranking/view/ranking_page.dart';
+import 'package:spicy_ranking/view/start_page.dart';
 
 class AppScreen extends StatefulWidget {
   const AppScreen({Key? key}) : super(key: key);
 
-  // タブバーとそれに連動するタブページを表示する
+  // start_pageを表示
   @override
-  TabBarPageState createState() => TabBarPageState();
+  StartPageState createState() => StartPageState();
+
+  // タブバーとそれに連動するタブページを表示する
+  // @override
+  // TabBarPageState createState() => TabBarPageState();
 
   // ページを表示するだけの
   // Widget build(BuildContext context) {
@@ -26,6 +31,17 @@ class AppScreen extends StatefulWidget {
   //     elevation: 10,
   //   );
   // }
+}
+
+class StartPageState extends State<AppScreen> {
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Start(),
+    );
+  }
+
 }
 
 class TabBarPageState extends State<AppScreen> {

--- a/lib/view/start_page.dart
+++ b/lib/view/start_page.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class Start extends StatelessWidget {
+  const Start({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            // 水平方向にpaddingが入っている
+            padding: EdgeInsets.symmetric(vertical: 100),
+            child: Align(
+              alignment: Alignment.center,
+              child: Text(
+                "SPICY-RANKINGへ\nようこそ",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontWeight: FontWeight.bold, 
+                  fontSize: 36
+                ),
+              ),
+            ),
+          ),
+          Container(
+            alignment: Alignment.bottomCenter,
+            child: SizedBox(
+              width: 250,
+              height: 120,
+              child: ElevatedButton(
+                onPressed: () {/* ボタンが押された時の処理 */},
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.lightGreenAccent[400],
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                child: const Text(
+                  'はじめる',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 36
+                    ),
+                  ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Issue
#24 
## やったこと
- スタートページを作成
## やってないこと
- ボタンが押された後のユーザー登録処理
- ボタンが押された後のルーティング
## 追記
- app.dartではじめに表示させる画面をstart.dartに変えたから、開発する時はここを変更してほしい
## 画面
![image](https://github.com/spicy-ranking/spicy-ranking/assets/86425759/1d6d8484-180b-4f5b-a8a0-da720d0d8beb)
