### PR TITLE
startPageからrankPageに画面遷移

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 // 最初に表示される画面
 import 'package:flutter/material.dart';
+import 'package:spicy_ranking/routing/start_route.dart';
 import 'package:spicy_ranking/view/input_page.dart';
 import 'package:spicy_ranking/view/ranking_page.dart';
 import 'package:spicy_ranking/view/start_page.dart';
@@ -44,7 +45,7 @@ class StartPageState extends State<AppScreen> {
 
 }
 
-class TabBarPageState extends State<AppScreen> {
+class TabBarPageState extends State<StartRoute> {
   // タブバーで表示するアイコンのリストを_tabに格納
   final tab = <Tab>[
     const Tab(text: "Ranking"),

--- a/lib/routing/start_route.dart
+++ b/lib/routing/start_route.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:spicy_ranking/app.dart';
+
+class StartRoute extends StatefulWidget {
+  const StartRoute({Key? key}) :super(key: key);
+
+  @override
+  TabBarPageState createState() => TabBarPageState();
+
+}

--- a/lib/view/start_page.dart
+++ b/lib/view/start_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:spicy_ranking/routing/start_route.dart';
 
 class Start extends StatelessWidget {
   const Start({Key? key}) : super(key: key);
@@ -30,7 +31,12 @@ class Start extends StatelessWidget {
               width: 250,
               height: 120,
               child: ElevatedButton(
-                onPressed: () {/* ボタンが押された時の処理 */},
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => const StartRoute()),
+                  );
+                },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.lightGreenAccent[400],
                   shape: RoundedRectangleBorder(


### PR DESCRIPTION
## Issue
#26 
## やったこと
- スタートページからランキングページに画面遷移した
  - ルーティングようのディレクトリを作成（作ったけどいらないかも...）
  - start_page -> routing/start_route -> ranking_pageのようなながれ
## やってないこと
- 画面遷移時にユーザーを自動登録（いまのところ作らない予定）


https://github.com/spicy-ranking/spicy-ranking/assets/86425759/ad0e2435-d05a-4c77-9104-67043984158e

