### PR TITLE
履歴ページUI

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -110,7 +110,7 @@ SPEC CHECKSUMS:
   FirebaseAuth: 21d5e902fcea44d0d961540fc4742966ae6118cc
   FirebaseCore: b68d3616526ec02e4d155166bbafb8eca64af557
   FirebaseCoreInternal: d2b4acb827908e72eca47a9fd896767c3053921e
-  FirebaseFirestore: bfafc0d3ecf3e9f1a706c4a3fa1567c09d9f83fd
+  FirebaseFirestore: 8418f3a8d5892bf386b05d5f988b6e7e253a2ea6
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
   GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:spicy_ranking/view/input_page.dart';
 import 'package:spicy_ranking/view/ranking_page.dart';
+import 'package:spicy_ranking/view/history_page.dart';
 
 class AppScreen extends StatefulWidget {
   const AppScreen({Key? key}) : super(key: key);
@@ -33,6 +34,7 @@ class TabBarPageState extends State<AppScreen> {
   final tab = <Tab>[
     const Tab(text: "Ranking"),
     const Tab(text: "Input"),
+    const Tab(text: "History")
   ];
 
   // TabBar,TabBarView, DefaultTabControllerを使い、タブバーとそれに連動するタブページを表示
@@ -44,12 +46,12 @@ class TabBarPageState extends State<AppScreen> {
         appBar: AppBar(
           title: const Text('SPICY-RANKING'),
           backgroundColor: Colors.red[400],
-          // elevatino: widgetが浮いてるような影をつける
+          // elevation: widgetが浮いてるような影をつける
           elevation: 10,
           bottom: TabBar(tabs: tab),
         ),
         body: const TabBarView(
-          children: <Widget>[RankPage(), Input()],
+          children: <Widget>[RankPage(), Input(), HistoryPage()],
         ),
       ),
     );

--- a/lib/view/history_page.dart
+++ b/lib/view/history_page.dart
@@ -1,0 +1,77 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+class History { //履歴クラス
+  final String hot; //辛いもの
+  final String cold; //辛くないもの
+  final int good; //賛成数
+  final int bad; //反対数
+
+  History({required this.hot, required this.cold, required this.good, required this.bad});
+
+  factory History.fromMap(Map<String, dynamic> data) {
+    return History(hot: data['hot'], cold: data['cold'], good: data['good'], bad: data['bad']);
+  }
+}
+
+class HistoryPage extends StatelessWidget {
+  const HistoryPage({super.key});
+
+  // Streamを使用して、モデルクラスから、データを取得するメソッド
+  Stream<List<History>> _fetchHistorysStream() {
+    final firestore = FirebaseFirestore.instance;
+    final stream = firestore.collection('history').snapshots();
+    return stream.map((snapshot) =>
+        snapshot.docs.map((doc) => History.fromMap(doc.data())).toList());
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    // ListとHistoryクラスを指定する
+    return StreamBuilder<List<History>>(
+      // 上で定義したメソッドを使用する
+      stream: _fetchHistorysStream(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        }
+
+        final historys = snapshot.data!;
+        return ListView.builder(
+          // Listのデータの数を数える
+          itemCount: historys.length,
+          itemBuilder: (context, index) {
+            // index番目から数えて、０〜末尾まで登録されているデータを表示する変数
+            final history = historys[index];
+            return ListTile(
+              // Historyクラスのメンバ変数を使用する
+              title: Text('hot: ${history.hot}'),
+              subtitle: Text('cold: ${history.cold}'),
+              leading: const Icon(Icons.account_circle),
+              trailing: Wrap(
+                spacing: 20,
+                children:[
+                  IconButton(
+                    icon: const Icon(Icons.thumb_up),
+                    color:Colors.red,
+                    onPressed:(){}//good + 1
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.thumb_down),
+                    color:Colors.blue,
+                    onPressed: (){}//bad + 1)
+                  )
+                ]
+              )
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/view/history_page.dart
+++ b/lib/view/history_page.dart
@@ -66,7 +66,7 @@ class HistoryPage extends StatelessWidget {
                     )
                   ),
                   OutlinedButton.icon(
-                    onPressed:() {history.bad += 1;},
+                    onPressed:() {},
                     icon: const Icon(Icons.thumb_down),
                     label:Text('${history.bad}'),
                     style:OutlinedButton.styleFrom(

--- a/lib/view/history_page.dart
+++ b/lib/view/history_page.dart
@@ -2,10 +2,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
 class History { //履歴クラス
-  final String hot; //辛いもの
-  final String cold; //辛くないもの
-  final int good; //賛成数
-  final int bad; //反対数
+  late String hot; //辛いもの
+  late String cold; //辛くないもの
+  late int good; //賛成数
+  late int bad; //反対数
 
   History({required this.hot, required this.cold, required this.good, required this.bad});
 
@@ -44,34 +44,37 @@ class HistoryPage extends StatelessWidget {
         final historys = snapshot.data!;
         return ListView.builder(
           // Listのデータの数を数える
+          itemExtent: 80,
           itemCount: historys.length,
           itemBuilder: (context, index) {
             // index番目から数えて、０〜末尾まで登録されているデータを表示する変数
             final history = historys[index];
-            bool selected = false;
             return ListTile(
               // Historyクラスのメンバ変数を使用する
-              title: Text('hot: ${history.hot}'),
-              subtitle: Text('cold: ${history.cold}'),
+              title: Text('🥵: ${history.hot}'),
+              subtitle: Text('🙂: ${history.cold}'),
               leading: const Icon(Icons.account_circle),
               trailing: Wrap(
-                spacing: 20,
-                children:[
-                  IconButton(
-                    icon: const Icon(Icons.thumb_up_outlined),
-                    color:Colors.red,
-                    onPressed:(){
-                        selected = !selected;
-                      },
-                    isSelected: selected,
-                    selectedIcon: const Icon(Icons.thumb_up),//good + 1
+                
+                children: [
+                  OutlinedButton.icon(
+                    onPressed:() {},
+                    icon: const Icon(Icons.thumb_up),
+                    label:Text('${history.good}'),
+                    style:OutlinedButton.styleFrom(
+                      primary:Colors.red,
+                    )
                   ),
-                  IconButton(
+                  OutlinedButton.icon(
+                    onPressed:() {history.bad += 1;},
                     icon: const Icon(Icons.thumb_down),
-                    color:Colors.blue,
-                    onPressed: (){}//bad + 1)
-                  )
-                ]
+                    label:Text('${history.bad}'),
+                    style:OutlinedButton.styleFrom(
+                      primary: Colors.blue,
+                    )
+                  ),
+
+                ],
               )
             );
           },

--- a/lib/view/history_page.dart
+++ b/lib/view/history_page.dart
@@ -48,6 +48,7 @@ class HistoryPage extends StatelessWidget {
           itemBuilder: (context, index) {
             // index番目から数えて、０〜末尾まで登録されているデータを表示する変数
             final history = historys[index];
+            bool selected = false;
             return ListTile(
               // Historyクラスのメンバ変数を使用する
               title: Text('hot: ${history.hot}'),
@@ -57,9 +58,13 @@ class HistoryPage extends StatelessWidget {
                 spacing: 20,
                 children:[
                   IconButton(
-                    icon: const Icon(Icons.thumb_up),
+                    icon: const Icon(Icons.thumb_up_outlined),
                     color:Colors.red,
-                    onPressed:(){}//good + 1
+                    onPressed:(){
+                        selected = !selected;
+                      },
+                    isSelected: selected,
+                    selectedIcon: const Icon(Icons.thumb_up),//good + 1
                   ),
                   IconButton(
                     icon: const Icon(Icons.thumb_down),


### PR DESCRIPTION
やったこと:
履歴ページの作成
firestoreからコレクションhistoryにあるデータを反映

やってないこと:
送信ボタンからの履歴登録
いいねボタン等のカウント、レート反映
↑HistoryPageをstatefulwidgetで作る必要あるかも


<img width="323" alt="スクリーンショット 2023-06-10 20 25 24" src="https://github.com/spicy-ranking/spicy-ranking/assets/85013672/2f17e6bf-f2de-42a1-906c-152bd60f37ec">
