### PR TITLE
入力画面から履歴データ追加＋履歴からレート反映

### DIFF
--- a/lib/view/history_page.dart
+++ b/lib/view/history_page.dart
@@ -1,16 +1,18 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
+
 class History { //履歴クラス
+  late String id; // ドキュメントID
   late String hot; //辛いもの
   late String cold; //辛くないもの
   late int good; //賛成数
   late int bad; //反対数
 
-  History({required this.hot, required this.cold, required this.good, required this.bad});
+  History({required this.id, required this.hot, required this.cold, required this.good, required this.bad});
 
-  factory History.fromMap(Map<String, dynamic> data) {
-    return History(hot: data['hot'], cold: data['cold'], good: data['good'], bad: data['bad']);
+  factory History.fromMap(String id, Map<String, dynamic> data) {
+    return History(id: id, hot: data['hot'], cold: data['cold'], good: data['good'], bad: data['bad']);
   }
 }
 
@@ -21,8 +23,10 @@ class HistoryPage extends StatelessWidget {
   Stream<List<History>> _fetchHistorysStream() {
     final firestore = FirebaseFirestore.instance;
     final stream = firestore.collection('history').snapshots();
-    return stream.map((snapshot) =>
-        snapshot.docs.map((doc) => History.fromMap(doc.data())).toList());
+    return stream.map((snapshot) => snapshot.docs.map((doc) {
+          final historyId = doc.id;
+          return History.fromMap(historyId, doc.data());
+        }).toList());
   }
 
 
@@ -55,18 +59,31 @@ class HistoryPage extends StatelessWidget {
               subtitle: Text('🙂: ${history.cold}'),
               leading: const Icon(Icons.account_circle),
               trailing: Wrap(
-                
                 children: [
                   OutlinedButton.icon(
-                    onPressed:() {},
+                    onPressed:() async{
+                      CollectionReference historyCollection = FirebaseFirestore.instance.collection('history');
+                      // クリックされた履歴のIDを取得
+                      await historyCollection.doc(history.id).update({
+                        'good': history.good + 1,
+                      });
+                    },
                     icon: const Icon(Icons.thumb_up),
                     label:Text('${history.good}'),
                     style:OutlinedButton.styleFrom(
                       primary:Colors.red,
                     )
+                    
                   ),
+                  
                   OutlinedButton.icon(
-                    onPressed:() {},
+                    onPressed:() async{
+                      CollectionReference historyCollection = FirebaseFirestore.instance.collection('history');
+                      // クリックされた履歴のIDを取得
+                      await historyCollection.doc(history.id).update({
+                        'bad': history.bad + 1,
+                    });
+                    },
                     icon: const Icon(Icons.thumb_down),
                     label:Text('${history.bad}'),
                     style:OutlinedButton.styleFrom(

--- a/lib/view/input_page.dart
+++ b/lib/view/input_page.dart
@@ -19,6 +19,8 @@ class _InputState extends State<Input> {
   String? firstProductName;
   String? secondProductName;
   String? hotCold;
+  String? firstProductNameHis; //履歴用
+  String? secondProductNameHis; //履歴用
   int firstRate = 0;
   int secondRate = 0;
   callback(String? product) {
@@ -112,6 +114,8 @@ class _InputState extends State<Input> {
                           if (querySnapshot.docs.isNotEmpty) {
                             firstRate = (querySnapshot.docs.first.data()
                                 as Map<String, dynamic>)['rate'];
+                            firstProductNameHis = (querySnapshot.docs.first.data()
+                                as Map<String, dynamic>)['name'];
                             debugPrint('First Rate: $firstRate');
                           } else {
                             debugPrint('No documents1.');
@@ -134,6 +138,8 @@ class _InputState extends State<Input> {
                           if (querySnapshot.docs.isNotEmpty) {
                             secondRate = (querySnapshot.docs.first.data()
                                 as Map<String, dynamic>)['rate'];
+                            secondProductNameHis = (querySnapshot.docs.first.data()
+                                as Map<String, dynamic>)['name'];
                             debugPrint('Second Rate: $secondRate');
                           } else {
                             debugPrint('No documents2.');
@@ -142,17 +148,34 @@ class _InputState extends State<Input> {
                   } else {
                     debugPrint("these are null");
                   }
-
+                  
                   if (hotCold == "辛い") {
                     int deltaRate =
                         32 ~/ ((pow(10, (firstRate - secondRate) / 400)) + 1);
                     firstRate = firstRate + deltaRate;
                     secondRate = secondRate - deltaRate;
+
+                    // 履歴データ追加
+                    FirebaseFirestore.instance.collection('history').add({
+                    'hot' : firstProductNameHis,
+                    'cold' : secondProductNameHis,
+                    'good' : 0,
+                    'bad' : 0,
+                    });
+
                   } else if (hotCold == "辛くない") {
                     int deltaRate =
                         32 ~/ ((pow(10, (secondRate - firstRate) / 400)) + 1);
                     firstRate = firstRate - deltaRate;
                     secondRate = secondRate + deltaRate;
+
+                    // 履歴データ追加
+                    FirebaseFirestore.instance.collection('history').add({
+                    'hot' : secondProductNameHis,
+                    'cold' : firstProductNameHis,
+                    'good' : 0,
+                    'bad' : 0,
+                    });
                   }
 
                   debugPrint('New First Rate: $firstRate');


### PR DESCRIPTION
やったこと:
・辛いもの、辛くないものの入力受付後、コレクションhistoryにデータ追加
・履歴のいいねボタンカウント
・いいね、よくないねボタンからレート反映

やってないこと:
・履歴の文字がグチャってるとこの修正
・いいねボタンの入力、カウント制限
・履歴データの表示数制限

https://github.com/spicy-ranking/spicy-ranking/assets/85013672/d6f351ad-f242-4e39-b969-c4169983c529


