### PR TITLE
送信ボタンを押した後ランキングページに遷移

### DIFF
--- a/lib/view/input_page.dart
+++ b/lib/view/input_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:spicy_ranking/app.dart';
 import 'package:spicy_ranking/constant/constants.dart';
 import 'package:spicy_ranking/components/drop_box_hot_menu.dart';
+import 'package:spicy_ranking/routing/start_route.dart';
 import '../components/drop_box_product_menu.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'dart:math';
@@ -223,7 +224,7 @@ class _InputState extends State<Input> {
                   Navigator.push(
                       context,
                       MaterialPageRoute(
-                          builder: (context) => const AppScreen()));
+                          builder: (context) => const StartRoute()));
                 },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.lightGreenAccent[400],


### PR DESCRIPTION
## Issue
#33 
##  やったこと
- インプットページの送信ボタンを押した後、スタートボタンに画面遷移していたのをランキングページに遷移するようにした

https://github.com/spicy-ranking/spicy-ranking/assets/86425759/16a360e1-8994-4229-8a5c-712c1165077f


