### PR TITLE
スタート画面のルーティング修正 #58

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -40,14 +40,12 @@ class AppScreen extends StatefulWidget {
 }
 
 class StartPageState extends State<AppScreen> {
-
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
       body: Start(),
     );
   }
-
 }
 
 class TabBarPageState extends State<StartRoute> {
@@ -64,12 +62,14 @@ class TabBarPageState extends State<StartRoute> {
   void initState() {
     super.initState();
     // FirebaseAuthのauthStateChanges() ストリームを監視
-    authStateSubscription = FirebaseAuth.instance.authStateChanges().listen((User? user) {
+    authStateSubscription =
+        FirebaseAuth.instance.authStateChanges().listen((User? user) {
       // ログイン状態を更新
       final newUserLoggedIn = user != null;
 
       if (newUserLoggedIn != isUserLoggedIn) {
-        if (mounted) { // ウィジェットがまだマウントされているかどうかを確認
+        if (mounted) {
+          // ウィジェットがまだマウントされているかどうかを確認
           setState(() {
             isUserLoggedIn = newUserLoggedIn;
           });
@@ -95,7 +95,7 @@ class TabBarPageState extends State<StartRoute> {
           actions: <Widget>[
             if (isUserLoggedIn)
               IconButton(
-                icon: const Icon(Icons.logout), 
+                icon: const Icon(Icons.logout),
                 onPressed: () async {
                   await FirebaseAuth.instance.signOut();
                 },
@@ -105,10 +105,17 @@ class TabBarPageState extends State<StartRoute> {
           automaticallyImplyLeading: false,
           // elevation: widgetが浮いてるような影をつける
           elevation: 10,
-          bottom: TabBar(tabs: tab),
+          bottom: TabBar(
+            tabs: tab,
+            indicatorColor: Colors.white,
+          ),
         ),
         body: TabBarView(
-          children: <Widget>[const RankPage(), LoginJudgeInput(), LoginJudgeHistory()],
+          children: <Widget>[
+            const RankPage(),
+            LoginJudgeInput(),
+            LoginJudgeHistory()
+          ],
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,6 @@ import 'app.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'infra/firebase_options.dart';
 
-
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
@@ -17,29 +16,14 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return  MaterialApp(
-
-      home: const AppScreen(),
-      //右上に出る"Debag"マークをけす
-      debugShowCheckedModeBanner: false,
-      initialRoute: '/',
-      routes: <String, WidgetBuilder> {
-        '/login': (BuildContext context) => UserLogin(),
-        '/regis': (BuildContext context) => Register(),
-      }
-      // stream_page表示
-      // home: Scaffold(
-      //   appBar: AppBar(title: const Text('カップ麺一覧')),
-      //   body: const StreamPage(),
-      // ),
-
-      // title: 'Flutter Demo',
-      // theme: ThemeData(
-      //    textTheme: Theme.of(context).textTheme.apply(bodyColor: kTextColor),
-      //    colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      //    useMaterial3: true,
-      // ),
-      
-    );
+    return MaterialApp(
+        home: const AppScreen(),
+        //右上に出る"Debag"マークをけす
+        debugShowCheckedModeBanner: false,
+        initialRoute: '/',
+        routes: <String, WidgetBuilder>{
+          '/login': (BuildContext context) => UserLogin(),
+          '/regis': (BuildContext context) => Register(),
+        });
   }
 }

--- a/lib/view/login_page.dart
+++ b/lib/view/login_page.dart
@@ -11,6 +11,7 @@ class UserLogin extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: Colors.blueGrey[400],
         title: const Text('ログイン'),
       ),
       body: Column(
@@ -39,14 +40,17 @@ class UserLogin extends StatelessWidget {
             ),
           ),
           ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.blueGrey[400],
+            ),
             child: const Text('ログイン'),
             onPressed: () async {
               try {
                 final newUser = await _auth.signInWithEmailAndPassword(
                     email: email, password: password);
                 if (newUser != null) {
-                    Navigator.of(context).pop();
-                    ScaffoldMessenger.of(context).showSnackBar(
+                  Navigator.of(context).pop();
+                  ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(
                       content: Text('ログインしました'),
                     ),

--- a/lib/view/login_restrict_page.dart
+++ b/lib/view/login_restrict_page.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 class UserLogin_restrict extends StatelessWidget {
-  final _auth = FirebaseAuth.instance;
-
   String email = '';
   String password = '';
 
@@ -12,25 +10,26 @@ class UserLogin_restrict extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('ログイン者限定の機能です'),
-        automaticallyImplyLeading: false
+        automaticallyImplyLeading: false,
+        backgroundColor: Colors.blueGrey[400],
       ),
       body: Center(
-        child: Column(
-        children: [
-          const SizedBox(height: 30),
-          TextButton(
-              onPressed: () {
-                Navigator.of(context).pushNamed('/login', arguments: 'login');
-              },
-              child: const Text('ログインはこちらから')),
-          TextButton(
-              onPressed: () {
-                Navigator.of(context).pushNamed('/regis', arguments: 'regis');
-              },
-              child: const Text('新規登録はこちらから'))
-        ]
-        )
-      ),
+          child: Column(children: [
+        const SizedBox(height: 30),
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pushNamed('/login', arguments: 'login');
+          },
+          child: const Text('ログインはこちらから',
+              style: TextStyle(color: Colors.blueGrey)),
+        ),
+        TextButton(
+            onPressed: () {
+              Navigator.of(context).pushNamed('/regis', arguments: 'regis');
+            },
+            child: const Text('新規登録はこちらから',
+                style: TextStyle(color: Colors.blueGrey)))
+      ])),
     );
   }
 }

--- a/lib/view/register_page.dart
+++ b/lib/view/register_page.dart
@@ -2,7 +2,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-
 class Register extends StatelessWidget {
   //ステップ１
   final _auth = FirebaseAuth.instance;
@@ -14,6 +13,7 @@ class Register extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: Colors.blueGrey[400],
         title: const Text('新規登録'),
       ),
       body: Column(
@@ -42,6 +42,9 @@ class Register extends StatelessWidget {
             ),
           ),
           ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.blueGrey[400],
+            ),
             child: const Text('新規登録'),
             //ステップ２
             onPressed: () async {
@@ -49,9 +52,12 @@ class Register extends StatelessWidget {
                 final newUser = await _auth.createUserWithEmailAndPassword(
                     email: email, password: password);
                 if (newUser != null) {
-                  final userId =FirebaseAuth.instance.currentUser?.uid;
+                  final userId = FirebaseAuth.instance.currentUser?.uid;
                   // FirestoreにユーザーIDを書き込む
-                  await FirebaseFirestore.instance.collection('users').doc(userId).set({'tap_count': 0, "time" : 0});
+                  await FirebaseFirestore.instance
+                      .collection('users')
+                      .doc(userId)
+                      .set({'tap_count': 0, "time": 0});
                   Navigator.of(context).pop(); //元の画面に戻る
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(

--- a/lib/view/start_page.dart
+++ b/lib/view/start_page.dart
@@ -55,7 +55,7 @@ class Start extends StatelessWidget {
                     ),
                   ),
                   child: const Text(
-                    '会員登録',
+                    '新規登録',
                     style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
                   ),
                 ),

--- a/lib/view/start_page.dart
+++ b/lib/view/start_page.dart
@@ -26,11 +26,7 @@ class Start extends StatelessWidget {
                 height: 50,
                 child: ElevatedButton(
                   onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) => const StartRoute()),
-                    );
+                    Navigator.pushNamed(context, '/login');
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: const Color.fromARGB(255, 34, 12, 6),
@@ -50,11 +46,7 @@ class Start extends StatelessWidget {
                 height: 50,
                 child: ElevatedButton(
                   onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) => const StartRoute()),
-                    );
+                    Navigator.pushNamed(context, '/regis');
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: const Color.fromARGB(255, 34, 12, 6),


### PR DESCRIPTION
# 実装内容
- スタート 画面で「ログイン」、「会員登録」を押した場合にそれぞれログインページ、登録ページに飛ぶように修正
- ログインページ, 登録ページの色修正

# 動画


https://github.com/spicy-ranking/spicy-ranking/assets/86425759/0facb068-4e76-4813-979f-009623254687



# 留意事項
- 動画ではログインページとかの色が変わってないけど、その後のコミットにきちんと変えてます

こんな感じ
![simulator_screenshot_52C1BA38-5034-429B-ACFC-A4CAF6EF1F3A](https://github.com/spicy-ranking/spicy-ranking/assets/86425759/1269ab32-1cbf-41d1-9cdb-14af605bfb62)